### PR TITLE
Support to build on arm64 architecture

### DIFF
--- a/opus_flutter_android/android/Android.mk
+++ b/opus_flutter_android/android/Android.mk
@@ -1,75 +1,82 @@
-LOCAL_PATH := $(call my-dir)/libopus
+ROOT := $(call my-dir)
+
+#Build libopus
+
 include $(CLEAR_VARS)
+LOCAL_PATH			:= $(ROOT)/libopus
+
+#include the .mk files
 include $(LOCAL_PATH)/celt_sources.mk
-include $(LOCAL_PATH)/opus_sources.mk
 include $(LOCAL_PATH)/silk_sources.mk
-LOCAL_MODULE    := opus
-LOCAL_OPUS_VERSION :='"1.3.1"'
-# To use fixed instead of floating point arithmetic, set this to true
-LOCAL_FIXED := false
+include $(LOCAL_PATH)/opus_sources.mk
 
-ifeq ($(TARGET_ARCH_ABI),$(filter $(TARGET_ARCH_ABI), armeabi-v7a))
-	LOCAL_ARM_NEON := true
-	# it seems that if we want to use neon optimizations we always need fixed
-	LOCAL_FIXED := true
-endif
+LOCAL_MODULE        := opus
 
-LOCAL_C_INCLUDES += $(LOCAL_PATH)/include \
-					$(LOCAL_PATH)/src $(LOCAL_PATH)/silk \
-                    $(LOCAL_PATH)/celt $(OGG_DIR)/include
-LOCAL_SRC_FILES := $(CELT_SOURCES) $(SILK_SOURCES) \
-                   $(OPUS_SOURCES) $(OPUS_SOURCES_FLOAT)
-LOCAL_CFLAGS        := -DPACKAGE_VERSION=$(LOCAL_OPUS_VERSION) \
-					   -DNULL=0 -DSOCKLEN_T=socklen_t -DLOCALE_NOT_USED \
-                       -D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
-                       -Drestrict='' -D__EMX__ -DOPUS_BUILD \
-                       -DUSE_ALLOCA -DHAVE_LRINT -DHAVE_LRINTF -O2 -fno-math-errno
-LOCAL_CPPFLAGS      := -DBSD=1 -ffast-math -O2 -funroll-loops
+#fixed point sources
+SILK_SOURCES += $(SILK_SOURCES_FIXED)
 
+#ARM build
+CELT_SOURCES += $(CELT_SOURCES_ARM)
+SILK_SOURCES += $(SILK_SOURCES_ARM)
 
-ifeq ($(LOCAL_FIXED),true)
-	LOCAL_C_INCLUDES += $(LOCAL_PATH)/silk/fixed
-	LOCAL_SRC_FILES += $(SILK_SOURCES_FIXED)
-	LOCAL_CFLAGS        += -DFIXED_POINT
-else
-	LOCAL_C_INCLUDES += $(LOCAL_PATH)/silk/float
-	LOCAL_SRC_FILES += $(SILK_SOURCES_FLOAT)
-endif
+#You need to include these sources from opus_sources.mk when compiling with float support.
+OPUS_SOURCES += $(OPUS_SOURCES_FLOAT) 
 
-# Note: OPUS enhanced DSP/NEON implementation is not yet compatible with arm64.
-# Only add the appropriate defines for 32-bit arm architecture.
-ifeq ($(LOCAL_ARM_NEON),true)
-	LOCAL_SRC_FILES += $(CELT_SOURCES_ARM)
-	LOCAL_CFLAGS += -DOPUS_ARM_ASM -DOPUS_ARM_INLINE_ASM \
-						-DOPUS_ARM_MAY_HAVE_EDSP -DOPUS_ARM_INLINE_EDSP \
-						-DOPUS_ARM_MAY_HAVE_MEDIA -DOPUS_ARM_INLINE_MEDIA \
-						-DOPUS_HAVE_RTCD
-	# DSP, MEDIA and NEON instructions are in the same assembler file - thus we
-	# need to include it even if NEON is not supported on target platform.
-	LOCAL_SRC_FILES += $(subst .s,_gnu.s,$(CELT_SOURCES_ARM_ASM))
+LOCAL_SRC_FILES     := \
+$(CELT_SOURCES) $(SILK_SOURCES) $(OPUS_SOURCES)
 
-	LOCAL_SRC_FILES += $(CELT_SOURCES_ARM_NEON_INTR) \
-					   $(SILK_SOURCES_ARM_NEON_INTR) \
-					   $(SILK_SOURCES_FIXED_ARM_NEON_INTR)
+#These are not needed when compiling static libraries, but I will keep in case you want to build dynamic ones.
+LOCAL_LDLIBS        := -lm -llog
 
-	LOCAL_CFLAGS += -DOPUS_ARM_MAY_HAVE_NEON -DOPUS_ARM_MAY_HAVE_NEON_INTR \
-						-DOPUS_ARM_PRESUME_NEON -DOPUS_ARM_INLINE_NEON
-endif
+LOCAL_C_INCLUDES    := \
+$(LOCAL_PATH)/include \
+$(LOCAL_PATH)/silk \
+$(LOCAL_PATH)/silk/fixed \
+$(LOCAL_PATH)/celt
 
-ifeq ($(TARGET_ARCH_ABI),$(filter $(TARGET_ARCH_ABI), x86 x86_64))
-	ifeq ($(ARCH_X86_HAVE_SSSE3),true)
-		LOCAL_SRC_FILES += $(CELT_SOURCES_SSE) $(CELT_SOURCES_SSE2)
-		LOCAL_CFLAGS += -DOPUS_X86_MAY_HAVE_SSE -DOPUS_X86_PRESUME_SSE \
-							-DOPUS_X86_MAY_HAVE_SSE2 -DOPUS_X86_PRESUME_SSE2
-	endif
-	ifeq ($(ARCH_X86_HAVE_SSE4_1),true)
-		LOCAL_SRC_FILES += $(CELT_SOURCES_SSE4_1) \
-						   $(SILK_SOURCES_SSE4_1)
-		ifeq ($(LOCAL_FIXED),true)
-			LOCAL_SRC_FILES += $(SILK_SOURCES_FIXED_SSE4_1)
-		endif
-		LOCAL_CFLAGS += -DOPUS_X86_MAY_HAVE_SSE4_1 -DOPUS_X86_PRESUME_SSE4_1
-	endif
-endif
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include
+
+LOCAL_CFLAGS        := -DNULL=0 -DSOCKLEN_T=socklen_t -DLOCALE_NOT_USED -D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64
+
+#Don't forget to remove the flag -DDISABLE_FLOAT_API
+LOCAL_CFLAGS        += -Drestrict='' -D__EMX__ -DOPUS_BUILD -DFIXED_POINT=1 -DUSE_ALLOCA -DHAVE_LRINT -DHAVE_LRINTF -O3 -fno-math-errno
+LOCAL_CFLAGS 		+= -DNDEBUG #Disable debug
+LOCAL_CFLAGS 		+= -O3 #Max optimization
+
+LOCAL_CPPFLAGS      := -DBSD=1
+LOCAL_CPPFLAGS      += -ffast-math -O3 -funroll-loops
+
+include $(BUILD_SHARED_LIBRARY)
+
+#Build libopusenc
+
+include $(CLEAR_VARS)
+LOCAL_PATH			:= $(ROOT)/libopusenc
+LOCAL_MODULE        := opusenc
+
+LOCAL_SRC_FILES := \
+	$(addprefix ../, $(shell cd $(LOCAL_PATH)/../; \
+	find $(LOCAL_PATH)/src -type f -name '*.c'))
+
+# LOCAL_LDLIBS        += -llog -lOpenSLES  -logg -lopus -L$(LOCAL_PATH)/lib
+LOCAL_C_INCLUDES    := \
+$(ROOT)/include \
+$(LOCAL_PATH)/include
+
+LOCAL_CFLAGS        := -DNULL=0 -DSOCKLEN_T=socklen_t -DLOCALE_NOT_USED -D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64
+LOCAL_CFLAGS        += -Drestrict='' -D__EMX__ -DOPUS_BUILD -DFIXED_POINT=1 -DUSE_ALLOCA -DHAVE_LRINT -DHAVE_LRINTF -O3 -fno-math-errno
+LOCAL_CFLAGS 		+= -DNDEBUG
+LOCAL_CFLAGS 		+= -O3
+
+LOCAL_CFLAGS 		+= -DPACKAGE_NAME='"CHANGE THE PACKAGE NAME"'
+LOCAL_CFLAGS     	+= -DPACKAGE_VERSION='"1.0.0"'
+LOCAL_CFLAGS		+= -DEXPORT=
+
+LOCAL_CPPFLAGS      := -DBSD=1
+LOCAL_CPPFLAGS      += -ffast-math -O3 -funroll-loops
+
+LOCAL_STATIC_LIBRARIES := opus
+
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include
 
 include $(BUILD_SHARED_LIBRARY)

--- a/opus_flutter_android/android/build.gradle
+++ b/opus_flutter_android/android/build.gradle
@@ -35,10 +35,17 @@ android {
 
     defaultConfig {
         minSdkVersion 19
+        ndk {
+            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+        }
     }
+    ndkVersion "26.3.11579264"
     externalNativeBuild {
         ndkBuild{
             path "Android.mk"
+        }
+        cmake {
+            version '3.22.1'
         }
     }
 


### PR DESCRIPTION
This pull request enforces specific versions of ndk and cmake (to use the latest versions) and adds ABI filters for ndk to enable building for arm64 devices as well.

NDK version 26.3.11579264
Cmake version 3.22.1